### PR TITLE
made port tooltips display a singular type

### DIFF
--- a/src/QuiltiX/qx_port.py
+++ b/src/QuiltiX/qx_port.py
@@ -73,8 +73,7 @@ class QxPortItem(NodeGraphQt.qgraphics.node_base.PortItem):
         return port_types
 
     def refresh_tool_tip(self):
-        port_types = self.get_port_types()
-        ttip = ", ".join(port_types)
+        ttip = self.get_port_types(current=True)
         self.setToolTip(ttip)
 
     def paint(self, painter, option, widget):


### PR DESCRIPTION
Now shows singular type tooltip instead of multiple types
![image](https://github.com/PrismPipeline/QuiltiX/assets/12091420/45731a56-b678-4f26-a56a-ea04e14d602e)
