### PR TITLE
Add render settings widget

### DIFF
--- a/src/QuiltiX/quiltix.py
+++ b/src/QuiltiX/quiltix.py
@@ -161,7 +161,7 @@ class QuiltiXWindow(QMainWindow):
             stage_view = StageView(dataModel=data_model)
 
             # region Stage View
-            self.stage_view_widget = usd_stage_view.StageViewWidget(data_model, stage_view)
+            self.stage_view_widget = self.get_stage_view_widget(data_model, stage_view)
             self.stage_view_widget.fileDropped.connect(self.on_view_file_dropped)
             self.stage_view_dock_widget = QDockWidget()
             self.stage_view_dock_widget.setWindowTitle("Viewport")
@@ -171,7 +171,7 @@ class QuiltiXWindow(QMainWindow):
             # endregion Stage View
 
             # region Render Settings
-            self.render_settings_widget = usd_render_settings.RenderSettingsWidget(stage_view)
+            self.render_settings_widget = self.get_render_settings_widget(stage_view)
             self.render_settings_dock_widget = QDockWidget()
             self.render_settings_dock_widget.setWindowTitle("Render Settings")
             self.render_settings_dock_widget.setWidget(self.render_settings_widget)
@@ -225,6 +225,12 @@ class QuiltiXWindow(QMainWindow):
 
     def get_stage_tree_widget(self):
         return usd_stage_tree.UsdStageTreeWidget()
+
+    def get_stage_view_widget(self, data_model, stage_view):
+        return usd_stage_view.StageViewWidget(data_model, stage_view)
+
+    def get_render_settings_widget(self, stage_view):
+        return usd_render_settings.RenderSettingsWidget(stage_view)
 
     def loadStylesheet(self):
         stylesheet_file = os.path.join(ROOT, "style.qss")

--- a/src/QuiltiX/quiltix.py
+++ b/src/QuiltiX/quiltix.py
@@ -26,8 +26,10 @@ from Qt.QtWidgets import (  # type: ignore
 )
 
 from pxr import UsdShade, Usd
+from pxr.Usdviewq.stageView import StageView # type: ignore
 import MaterialX as mx
 
+from QuiltiX import usd_render_settings
 from QuiltiX import usd_stage
 from QuiltiX import usd_stage_tree
 from QuiltiX import usd_stage_view
@@ -154,16 +156,31 @@ class QuiltiXWindow(QMainWindow):
         self.addDockWidget(QtCore.Qt.TopDockWidgetArea, self.stage_tree_dock_widget)
         # endregion Stage Tree
 
-        # region Stage View
         if self.viewer_enabled:
-            self.stage_view_widget = self.get_stage_view_widget()
+            data_model = StageView.DefaultDataModel()
+            stage_view = StageView(dataModel=data_model)
+
+            # region Stage View
+            self.stage_view_widget = usd_stage_view.StageViewWidget(data_model, stage_view)
             self.stage_view_widget.fileDropped.connect(self.on_view_file_dropped)
             self.stage_view_dock_widget = QDockWidget()
             self.stage_view_dock_widget.setWindowTitle("Viewport")
             self.stage_view_dock_widget.setWidget(self.stage_view_widget)
             self.stage_view_dock_widget.setAllowedAreas(QtCore.Qt.AllDockWidgetAreas)
             self.addDockWidget(QtCore.Qt.TopDockWidgetArea, self.stage_view_dock_widget)
-        # endregion Stage View
+            # endregion Stage View
+
+            # region Render Settings
+            self.render_settings_widget = usd_render_settings.RenderSettingsWidget(stage_view)
+            self.render_settings_dock_widget = QDockWidget()
+            self.render_settings_dock_widget.setWindowTitle("Render Settings")
+            self.render_settings_dock_widget.setWidget(self.render_settings_widget)
+            self.render_settings_dock_widget.setAllowedAreas(QtCore.Qt.AllDockWidgetAreas)
+            self.render_settings_dock_widget.setVisible(False)
+            self.addDockWidget(QtCore.Qt.RightDockWidgetArea, self.render_settings_dock_widget)
+
+            self.stage_view_widget.rendererChanged.connect(self.render_settings_widget.on_renderer_changed)
+            # endregion Render Settings
 
         # region Properties
         self.properties = PropertiesBinWidget(root_node_graph=self.qx_node_graph)
@@ -208,9 +225,6 @@ class QuiltiXWindow(QMainWindow):
 
     def get_stage_tree_widget(self):
         return usd_stage_tree.UsdStageTreeWidget()
-
-    def get_stage_view_widget(self):
-        return usd_stage_view.StageViewWidget()
 
     def loadStylesheet(self):
         stylesheet_file = os.path.join(ROOT, "style.qss")
@@ -370,6 +384,11 @@ class QuiltiXWindow(QMainWindow):
         self.act_prop.setCheckable(True)
         self.act_prop.toggled.connect(self.on_properties_toggled)
         self.view_menu.addAction(self.act_prop)
+
+        self.act_render_settings = QAction("Render Settings", self)
+        self.act_render_settings.setCheckable(True)
+        self.act_render_settings.toggled.connect(self.on_render_settings_toggled)
+        self.view_menu.addAction(self.act_render_settings)
 
         self.act_scenegraph = QAction("Scenegraph", self)
         self.act_scenegraph.setCheckable(True)
@@ -622,6 +641,9 @@ class QuiltiXWindow(QMainWindow):
 
     def on_properties_toggled(self, checked):
         self.properties_dock_widget.setVisible(checked)
+
+    def on_render_settings_toggled(self, checked):
+        self.render_settings_dock_widget.setVisible(checked)
 
     def on_scenegraph_toggled(self, checked):
         self.stage_tree_dock_widget.setVisible(checked)

--- a/src/QuiltiX/usd_render_settings.py
+++ b/src/QuiltiX/usd_render_settings.py
@@ -1,0 +1,60 @@
+from Qt.QtCore import Qt # type: ignore
+from Qt.QtWidgets import QDoubleSpinBox, QLineEdit, QFormLayout, QWidget, QCheckBox, QSpinBox  # type: ignore
+
+from pxr.Usdviewq.stageView import StageView, UsdImagingGL
+
+class RenderSettingsWidget(QWidget):
+
+    def __init__(self, stage_view, window_title="Render Settings"):
+        super(RenderSettingsWidget, self).__init__()
+        self.setAttribute(Qt.WA_StyledBackground, True)
+        self.stage_view = stage_view
+        self.layout = QFormLayout(self)
+
+    def on_renderer_changed(self):
+        self._clear_widgets()
+        self._populate_widgets()
+
+    def _clear_widgets(self):
+        for i in reversed(range(self.layout.count())):
+            widgetToRemove = self.layout.itemAt(i).widget()
+            self.layout.removeWidget(widgetToRemove)
+            widgetToRemove.setParent(None)
+
+    def _populate_widgets(self):
+        settings = self.stage_view.GetRendererSettingsList()
+
+        for setting in settings:
+            if setting.type == UsdImagingGL.RendererSettingType.FLAG:
+                checkBox = QCheckBox(self)
+                checkBox.setChecked(self.stage_view.GetRendererSetting(setting.key))
+                checkBox.key = str(setting.key)
+                checkBox.defValue = setting.defValue
+                checkBox.toggled.connect(lambda v, setting=setting: self.stage_view.SetRendererSetting(setting.key, v))
+                self.layout.addRow(setting.name, checkBox)
+            elif setting.type == UsdImagingGL.RendererSettingType.INT:
+                spinBox = QSpinBox(self)
+                spinBox.setMinimum(-2 ** 31)
+                spinBox.setMaximum(2 ** 31 - 1)
+                spinBox.setValue(self.stage_view.GetRendererSetting(setting.key))
+                spinBox.key = str(setting.key)
+                spinBox.defValue = setting.defValue
+                spinBox.valueChanged.connect(lambda v, setting=setting: self.stage_view.SetRendererSetting(setting.key, v))
+                self.layout.addRow(setting.name, spinBox)
+            elif setting.type == UsdImagingGL.RendererSettingType.FLOAT:
+                spinBox = QDoubleSpinBox(self)
+                spinBox.setDecimals(10)
+                spinBox.setMinimum(-2 ** 31)
+                spinBox.setMaximum(2 ** 31 - 1)
+                spinBox.setValue(self.stage_view.GetRendererSetting(setting.key))
+                spinBox.key = str(setting.key)
+                spinBox.defValue = setting.defValue
+                spinBox.valueChanged.connect(lambda v, setting=setting: self.stage_view.SetRendererSetting(setting.key, v))
+                self.layout.addRow(setting.name, spinBox)
+            elif setting.type == UsdImagingGL.RendererSettingType.STRING:
+                lineEdit = QLineEdit(self)
+                lineEdit.setText(self.stage_view.GetRendererSetting(setting.key))
+                lineEdit.key = str(setting.key)
+                lineEdit.defValue = setting.defValue
+                lineEdit.textChanged.connect(lambda v, setting=setting: self.stage_view.SetRendererSetting(setting.key, v))
+                self.layout.addRow(setting.name, lineEdit)

--- a/src/QuiltiX/usd_stage_view.py
+++ b/src/QuiltiX/usd_stage_view.py
@@ -18,14 +18,15 @@ logger = logging.getLogger(__name__)
 class StageViewWidget(QWidget):
     keyPressed = Signal(object, object)
     fileDropped = Signal(object)
+    rendererChanged = Signal(object)
 
-    def __init__(self, stage=None, window_title="USD Stageview"):
+    def __init__(self, data_model, stage_view, stage=None, window_title="USD Stageview"):
         super(StageViewWidget, self).__init__()
 
-        self.model = StageView.DefaultDataModel()
+        self.model = data_model
         self.model.viewSettings.showHUD = False
 
-        self.view = StageView(dataModel=self.model)
+        self.view = stage_view
         self.view.orig_handleRendererChanged = self.view._handleRendererChanged
         self.view._handleRendererChanged = self._handleRendererChanged
 
@@ -133,6 +134,7 @@ class StageViewWidget(QWidget):
     def _handleRendererChanged(self, rendererId):
         self.view.orig_handleRendererChanged(rendererId)
         self.apply_rendersettings_to_current_delegate()
+        self.rendererChanged.emit(rendererId)
 
     def apply_rendersettings_to_current_delegate(self):
         renderer_id = self.get_current_renderer()


### PR DESCRIPTION
This PR adds a widget that allows the user to interact with the Hydra render delegate settings. See it in action here:

https://github.com/PrismPipeline/QuiltiX/assets/3663466/d56dcce7-3bef-4bb8-bb9c-0543efefdcea
