### PR TITLE
added support for relative filepaths

### DIFF
--- a/src/QuiltiX/quiltix.py
+++ b/src/QuiltiX/quiltix.py
@@ -211,13 +211,12 @@ class QuiltiXWindow(QMainWindow):
         self.qx_node_graph_widget.setFocus()
 
     def on_mx_file_loaded(self, path):
+        self.set_current_filepath(path)
         graph_data = self.qx_node_graph.get_mx_xml_data_from_graph()
         self.stage_ctrl.refresh_mx_file(graph_data, emit=False)
         if self.act_apply_mat.isChecked():
             self.stage_ctrl.apply_first_material_to_all_prims()
         self.stage_tree_widget.refresh_tree()
-
-        self.set_current_filepath(path)
 
     def on_node_graph_changed(self, nodegraph):
         if self.act_apply_mat.isChecked():

--- a/src/QuiltiX/qx_nodegraph.py
+++ b/src/QuiltiX/qx_nodegraph.py
@@ -717,7 +717,6 @@ class QxNodeGraph(NodeGraphQt.NodeGraph):
                 if cur_mx_node.hasAttribute("xpos") and cur_mx_node.hasAttribute("ypos"):
                     had_pos = True
 
-                self.patch_relative_file_path_inputs(cur_mx_node, base_dir)
                 cur_qx_node = self.create_node_from_mx_node(cur_mx_node)
 
                 qx_node_to_mx_node[cur_qx_node] = cur_mx_node
@@ -725,7 +724,6 @@ class QxNodeGraph(NodeGraphQt.NodeGraph):
             for mx_graph in doc.getNodeGraphs():
                 ng_node = self.create_nodegraph_from_mx_nodegraph(mx_graph)
                 for cur_mx_node in mx_graph.getNodes():
-                    self.patch_relative_file_path_inputs(cur_mx_node, base_dir)
                     cur_qx_node = self.create_node_from_mx_node(cur_mx_node, graph=ng_node.get_sub_graph())
                     # Change value type of node
                     qx_node_to_mx_node[cur_qx_node] = cur_mx_node

--- a/src/QuiltiX/usd_stage.py
+++ b/src/QuiltiX/usd_stage.py
@@ -122,6 +122,12 @@ class MxStageController(QtCore.QObject):
         if in_memory:
             idf = "_tmp_quiltix_graph.mtlx"
             layer = Sdf.Layer.CreateAnonymous(idf)
+            cur_path = self.editor.current_filepath
+            if cur_path and cur_path != "untitled":
+                # allows relative filepaths
+                idf = os.path.join(os.path.dirname(cur_path), "_tmp_quiltix_graph.mtlx")
+                layer.identifier = idf
+
             idf = layer.identifier
             layer.ImportFromString(mx_data)
         else:


### PR DESCRIPTION
This change gives the anonymous mtlx layer an absolute filepath in the same directory as the currently open mtlx file. This allows relative filepaths to work.