### PR TITLE
texcoord Patch for Prman

### DIFF
--- a/src/QuiltiX/qx_nodegraph.py
+++ b/src/QuiltiX/qx_nodegraph.py
@@ -533,6 +533,8 @@ class QxNodeGraph(NodeGraphQt.NodeGraph):
                 else:
                     mx_input_type = mx_def.getActiveInput(input_data["name"]).getType()
 
+                if input_data["name"] == "texcoord" and val == (0.0, 0.0):
+                    continue
 
                 # temporary fix to avoid displacement validation warning
                 if node_data["type_"] == "Material.Surfacematerial" and input_data["name"] == "displacementshader":


### PR DESCRIPTION
When rendering a materialx graph that includes an image node for reading in a texture with RenderMan the texture tiling is off as can be seen in the image below:

<img width="1712" alt="bishop_renderman_without_patch" src="https://github.com/PrismPipeline/QuiltiX/assets/11925092/ce9fbc4f-19c7-4866-9328-76324100e372">

With the patch in this pull request the texture looks correct as seen below:
<img width="1712" alt="bishop_renderman_with_patch" src="https://github.com/PrismPipeline/QuiltiX/assets/11925092/0fb14731-6295-4e5b-84de-fc718bb92a9e">

This test was done using the [bishop_geom.usd](https://github.com/usd-wg/assets/blob/main/full_assets/OpenChessSet/assets/Bishop/Bishop_geom.usd) from the USD Asset Working Group as the geometry. Then
1. Create an image node and set its type to `color3`
2. Set the [bishop_black_base_color.jpg](https://github.com/usd-wg/assets/blob/main/full_assets/OpenChessSet/assets/Bishop/tex/bishop_black_base_color.jpg) from the USD Asset Working Group as the image for the image node
3. Create a Standard Surface
4. Connect the `out` of the image node to the base color of the standard surface
5. Create a Surface Material
6. Connect the `out` of the Standard Surface to the`surfaceshader` input of the Surface Material
7. Change the Renderer to Prman


Creating the same MaterialX material in Solaris does not produce the same issue as what's seen here in QuiltiX.

While there weren't any adverse effects from this patch noticed in Storm for Metal, the patch that's presented in this pull request is most likely not the proper fix. But perhaps the info provided here is sufficient to identify the proper fix.

This was tested with:
- USD-23.11 (Compiled with RenderMan and full OSL support)
- MaterialX 1.38.7
- RenderMan 25.2
- MacOS 13.6