### PR TITLE
Fix value setting when no previous value was set on an input

### DIFF
--- a/src/QuiltiX/qx_nodegraph.py
+++ b/src/QuiltiX/qx_nodegraph.py
@@ -631,7 +631,7 @@ class QxNodeGraph(NodeGraphQt.NodeGraph):
                 mx_input.setValueString(val)
                 mx_input.setAttribute("colorspace", "srgb_texture")
             else:
-                mx_input.setValue(val)
+                mx_input.setValue(val, mx_input_type)
 
     def get_current_graph_data(self):
         serialized_data = self.serialize_session()


### PR DESCRIPTION
# Issue

If an input does not already have a value set  then setValue() can change the type unless an explicit type is specified.
Fixes #41.

# Change

Fix `setValue()` to include type. Otherwise the interpretation of a value such as `0` can end up making the type become an integer. A tricky thing due to the API's side-effect logic of possibly changing type :(.

# Test

Create a new glTF PBR node and show the MaterialX text. It will show that `attenuation_distance` is the correct type `float` vs `integer`.

![image](https://github.com/PrismPipeline/QuiltiX/assets/49369885/968b5711-36ac-46ac-b99b-ed348195302d)


