### PR TITLE
Add ability to update QuiltiX graph from in-memory MaterialX document

### DIFF
--- a/src/QuiltiX/qx_nodegraph.py
+++ b/src/QuiltiX/qx_nodegraph.py
@@ -697,20 +697,23 @@ class QxNodeGraph(NodeGraphQt.NodeGraph):
             )
 
     def load_graph_from_mx_file(self, mx_file_path):
+        base_dir = os.path.dirname(os.path.abspath(mx_file_path))
+
+        doc = mx.createDocument()
+        # _libraryDir = os.path.join(os.path.join(self.core.extPath, "USD", "libraries"))
+        # _searchPath = _libraryDir + mx.PATH_LIST_SEPARATOR + _exampleDir
+        # _searchPath = _libraryDir
+
+        # mx.readFromXmlFile(doc, path, _searchPath)
+        mx.readFromXmlFile(doc, mx_file_path)
+        self.load_graph_from_mx_doc(doc, mx_file_path)
+
+    def load_graph_from_mx_doc(self, doc, mx_file_path):
         with self.get_root_graph().block_save():
             self.clear_session()
 
-            base_dir = os.path.dirname(os.path.abspath(mx_file_path))
-
-            doc = mx.createDocument()
-            # _libraryDir = os.path.join(os.path.join(self.core.extPath, "USD", "libraries"))
-            # _searchPath = _libraryDir + mx.PATH_LIST_SEPARATOR + _exampleDir
-            # _searchPath = _libraryDir
-
             had_pos = False
             qx_node_to_mx_node = {}
-            # mx.readFromXmlFile(doc, path, _searchPath)
-            mx.readFromXmlFile(doc, mx_file_path)
 
             # Create Nodes
             for cur_mx_node in doc.getNodes():

--- a/src/QuiltiX/qx_nodegraph.py
+++ b/src/QuiltiX/qx_nodegraph.py
@@ -706,9 +706,10 @@ class QxNodeGraph(NodeGraphQt.NodeGraph):
 
         # mx.readFromXmlFile(doc, path, _searchPath)
         mx.readFromXmlFile(doc, mx_file_path)
-        self.load_graph_from_mx_doc(doc, mx_file_path)
+        self.load_graph_from_mx_doc(doc)
+        self.mx_file_loaded.emit(mx_file_path)
 
-    def load_graph_from_mx_doc(self, doc, mx_file_path):
+    def load_graph_from_mx_doc(self, doc):
         with self.get_root_graph().block_save():
             self.clear_session()
 
@@ -742,8 +743,6 @@ class QxNodeGraph(NodeGraphQt.NodeGraph):
 
                 if not graph.is_root:
                     graph.parent_graph.collapse_group_node(graph.node)
-
-        self.mx_file_loaded.emit(mx_file_path)
 
     def load_image_file(self, filepath, xoffset=0, yoffset=0):
         local_pos = self.viewer().mapFromGlobal(QtGui.QCursor.pos())


### PR DESCRIPTION
## Issue

This allows for integrations which create an in-memory MaterialX doc which can be routed to QuiltiX to update it's graph.
Fixes #45 

## Changes

Split out the file read part of `load_graph_from_mx_file` into a `load_graph_from_mx_doc` (load from in memory document). The file handling part would stay in `load_graph_from_mx_file` which would call `load_graph_from_mx_doc`.


