### PR TITLE
Fix hot-key save call

### DIFF
--- a/src/QuiltiX/hotkeys/hotkey_functions.py
+++ b/src/QuiltiX/hotkeys/hotkey_functions.py
@@ -73,7 +73,7 @@ def save_session(graph):
         viewer = graph.viewer()
         viewer.message_dialog(msg, title='Session Saved')
     else:
-        _save_session_as(graph)
+        save_session_as(graph)
 
 
 def save_session_as(graph):


### PR DESCRIPTION
## Issue

The save hot-key calls `_save_session_as` but this function does not exist.

## Change

Minor fix call to `save_session_as` vs `_save_session_as` 