### PR TITLE
Fix to handle vector2 parameter value changes

### DIFF
--- a/src/QuiltiX/usd_stage.py
+++ b/src/QuiltiX/usd_stage.py
@@ -195,6 +195,8 @@ class MxStageController(QtCore.QObject):
 
             if len(property_value) == 3:
                 property_value = Gf.Vec3f(property_value)
+            elif len(property_value) == 2:
+                property_value = Gf.Vec2f(property_value)                
 
         usdinput.GetAttr().Set(property_value)
         self.signal_stage_updated.emit()


### PR DESCRIPTION
## Issue

Update #52 

## Change

Handle 2 parameter input to map to `Gf.Vec2f` type.

## Tested with issue file.

Changed value on `uvtiling` (vec2 type) and got this as debug output instead of erroring out with incorrect type.

```shell
DEBUG:QuiltiX.qx_nodegraph:property changed uvtiling - [1.0, 1.0]
```