### PR TITLE
Proposal : Allow for the ability to see USD Stage materials as text

### DIFF
--- a/src/QuiltiX/quiltix.py
+++ b/src/QuiltiX/quiltix.py
@@ -319,6 +319,10 @@ class QuiltiXWindow(QMainWindow):
         show_mx_text.triggered.connect(self.show_mx_text_triggered)
         self.file_menu.addAction(show_mx_text)
 
+        show_usd_text = QAction("Show USD as text...", self)
+        show_usd_text.triggered.connect(self.show_usd_text_triggered)
+        self.file_menu.addAction(show_usd_text)
+
         self.file_menu.addSeparator()
 
         show_mx_view = QAction("Open in MaterialX View...", self)
@@ -534,6 +538,27 @@ class QuiltiXWindow(QMainWindow):
         te_text.setReadOnly(True)
         te_text.setParent(self, QtCore.Qt.Window)
         te_text.setWindowTitle("MaterialX text preview")
+        te_text.resize(1000, 800)
+        te_text.show()
+
+    def print_usd_prim(self, prim):
+        assert isinstance(prim, Usd.Prim)
+        prim_stage = prim.GetStage()
+        prim_stage_id = prim_stage.GetRootLayer().identifier
+        stage = Usd.Stage.CreateInMemory()
+        target = stage.DefinePrim("/{}".format(prim.GetName()))
+        target.GetReferences().AddReference(prim_stage_id, prim.GetPath())        
+        return stage.ExportToString() 
+
+    def show_usd_text_triggered(self):
+        usdstage = self.stage_ctrl.stage
+        materials = usdstage.GetPrimAtPath("/MaterialX")
+        text = self.print_usd_prim(materials)
+        te_text = QTextEdit()
+        te_text.setText(text)
+        te_text.setReadOnly(True)
+        te_text.setParent(self, QtCore.Qt.Window)
+        te_text.setWindowTitle("USD text preview")
         te_text.resize(1000, 800)
         te_text.show()
 


### PR DESCRIPTION
## Proposal

It is useful for debugging and interop comparison to be able to see the USD Stage materials.
A simple way to do this is to add a "preview as text" as exists for MaterialX.

## Change
- Addition of "Show USD as text..." menu option.

![image](https://github.com/PrismPipeline/QuiltiX/assets/49369885/e6ab3e97-cdb0-4284-af64-0755dcd3dc61)
<sub>Figure: Shows new proposed menu item and the text box popup</sub>

## Logic

- Finds the `/MaterialX` prim and extracts it out using a new `print_usd_prim` utiltity which references the prim and exports the children as a string for display.
