### PR TITLE
Fix interfacename connection setting

### DIFF
--- a/src/QuiltiX/qx_nodegraph.py
+++ b/src/QuiltiX/qx_nodegraph.py
@@ -591,8 +591,8 @@ class QxNodeGraph(NodeGraphQt.NodeGraph):
             mx_input = mx_node.getActiveInput(connection["in"][1])
             if serialized_data["nodes"][connection["out"][0]]["type_"] in ["Inputs.QxPortInputNode"]:
                 mx_input.setInterfaceName(connection["out"][1])
+                mx_input.removeAttribute("value")
                 val = parent_graph_data["nodes"][parent_id].get("custom", {}).get(connection["out"][1])
-                self.set_mx_input_value(mx_input, val)
                 continue
             
             connected_mx_node = qx_node_ids_to_mx_nodes[connection["out"][0]]


### PR DESCRIPTION
## Interface Connection Setting

Fixes #59 

This change fixes the issue of creating both an `interfacename` connection and also setting a `value` on an input
when serizliating the input on a node in a graph. Only one should be specified to be valid.

e.g. Currently you get this for example which is invalid for "in`" on the "Add" node:

```xml
<nodegraph name="Nodegraph" xpos="-1.7653979153374229" ypos="3.8192409855171383">
    <add name="Add" type="float" xpos="3.9042865959028106" ypos="2.7340644554414775">
      <input name="in1" type="float" interfacename="in_Add" value="0" />
      <input name="in2" type="float" value="0" />
    </add>
    <output name="out_Add" type="float" nodename="Add" />
    <input name="in_Add" type="float" value="0" />
  </nodegraph>
```

This fix remove the value attribute to get this instead 

```xml
<nodegraph name="Nodegraph" xpos="-1.7653979153374229" ypos="3.8192409855171383">
    <add name="Add" type="float" xpos="3.9042865959028106" ypos="2.7340644554414775">
      <input name="in1" type="float" interfacename="in_Add" />
      <input name="in2" type="float" value="0" />
    </add>
    <output name="out_Add" type="float" nodename="Add" />
    <input name="in_Add" type="float" value="0" />
  </nodegraph>
```

Note that `nodename` and `nodegraph` settings are okay since the Python calls being made explicitly
remove the `value` attribute for you.