### PR TITLE
adding option to load MaterialX XML data instead of a file

### DIFF
--- a/src/QuiltiX/quiltix.py
+++ b/src/QuiltiX/quiltix.py
@@ -22,6 +22,7 @@ from qtpy.QtWidgets import (  # type: ignore
     QPushButton,
     QDialogButtonBox,
     QGridLayout,
+    QVBoxLayout,
     QSizePolicy,
     QComboBox,
 )
@@ -294,8 +295,12 @@ class QuiltiXWindow(QMainWindow):
         # endregion Tabs
 
         # region File
-        load_mx_file = QAction("Load MaterialX...", self)
+        load_mx_file = QAction("Load MaterialX file...", self)
         load_mx_file.triggered.connect(self.load_mx_file_triggered)
+        self.file_menu.addAction(load_mx_file)
+
+        load_mx_file = QAction("Load MaterialX data...", self)
+        load_mx_file.triggered.connect(self.load_mx_data_triggered)
         self.file_menu.addAction(load_mx_file)
 
         save_mx_file = QAction("Save MaterialX...", self)
@@ -506,6 +511,27 @@ class QuiltiXWindow(QMainWindow):
 
         self.mx_selection_path = path
         self.qx_node_graph.load_graph_from_mx_file(path)
+
+    def load_mx_data_triggered(self):
+        dlg = QDialog()
+        dlg.setParent(self, QtCore.Qt.Window)
+        dlg.setWindowTitle("MaterialX XML Data")
+        dlg.lo_main = QVBoxLayout(dlg)
+        dlg.te_text = QTextEdit()
+        dlg.bb_main = QDialogButtonBox()
+        dlg.bb_main.addButton("Load", QDialogButtonBox.AcceptRole)
+        dlg.bb_main.addButton("Cancel", QDialogButtonBox.RejectRole)
+        dlg.lo_main.addWidget(dlg.te_text)
+        dlg.lo_main.addWidget(dlg.bb_main)
+        dlg.bb_main.accepted.connect(dlg.accept)
+        dlg.bb_main.rejected.connect(dlg.reject)
+        dlg.resize(1000, 600)
+        result = dlg.exec_()
+        if result == 0:
+            return
+
+        xml_str = dlg.te_text.toPlainText()
+        self.qx_node_graph.load_graph_from_mx_data(xml_str)
 
     def save_mx_file_triggered(self):
         start_path = self.mx_selection_path

--- a/src/QuiltiX/qx_nodegraph.py
+++ b/src/QuiltiX/qx_nodegraph.py
@@ -714,8 +714,6 @@ class QxNodeGraph(NodeGraphQt.NodeGraph):
             )
 
     def load_graph_from_mx_file(self, mx_file_path):
-        base_dir = os.path.dirname(os.path.abspath(mx_file_path))
-
         doc = mx.createDocument()
         # _libraryDir = os.path.join(os.path.join(self.core.extPath, "USD", "libraries"))
         # _searchPath = _libraryDir + mx.PATH_LIST_SEPARATOR + _exampleDir
@@ -731,6 +729,17 @@ class QxNodeGraph(NodeGraphQt.NodeGraph):
         mx.readFromXmlFile(doc, mx_file_path)
         self.load_graph_from_mx_doc(doc)
         self.mx_file_loaded.emit(mx_file_path)
+
+    def load_graph_from_mx_data(self, mx_data):
+        doc = mx.createDocument()
+        try:
+            mx.readFromXmlString(doc, mx_data)
+        except Exception as e:
+            QtWidgets.QMessageBox.warning(self.get_root_graph().widget.parent(), "Warning", 'Failed to load XML data:\n\n%s' % e)
+            return
+
+        self.load_graph_from_mx_doc(doc)
+        self.mx_file_loaded.emit("")
 
     def load_graph_from_mx_doc(self, doc):
         with self.get_root_graph().block_save():


### PR DESCRIPTION
makes it easier to paste example graphs and graphs from Github issues.