### PR TITLE
Plugin Logic Proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,10 @@ def plugin_name() -> str:
 If your plugin has the possibility to not be valid (due to missing dependencies or similar) you can implement a `is_valid` function returning `False` to avoid it loading entirely. Example:
 ```python
 def is_valid() -> bool:
-    return has_materialxjson
+    if 1==1:
+      return False
+    else:
+      return True
   ```
 
 For further reference please take a look at the `sample_plugins` dir and the tests in `tests/test_plugins.py`

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ QuiltiX is a graphical node editor to edit, and author [MaterialX](https://mater
   - [From Source](#from-source)
 - [Running QuiltiX](#running-quiltix)
   - [Running QuiltiX using hython](#running-quiltix-using-hython)
+- [QuiltiX Plugins](#quiltix-plugins)
+  - [Creating a QuiltiX plugin](#creating-a-quiltix-plugin)
+  - [QuiltiX Plugin hooks](#quiltix-plugin-hooks)
 - [Integrating with your environment](#integrating-with-your-environment)
   - [Adding Hydra delegates](#adding-hydra-delegates)
     - [Arnold](#arnold)
@@ -117,6 +120,47 @@ set PYTHONPATH=%PYTHONPATH%;%VIRTUAL_ENV%/Lib/site-packages;./src
 ```
 > Note that currently both the Storm as well as HoudiniGL render delegates do not seem to work in QuiltiX when being launched from hython.
 </details>
+
+## QuiltiX Plugins
+
+QuiltiX supports adding Plugins via the environment variable `QUILTIX_PLUGIN_PATHS`. We are using [pluggy](https://pluggy.readthedocs.io/en/stable/) in the backend to load them.
+
+### Creating a QuiltiX plugin
+To create a QuiltiX plugin you need to create a `plugin.py` file. In this file you need implement one or multiple `hooks` that QuiltiX provides. Example:
+
+```python
+@qx_plugin.hookimpl
+def after_ui_init(editor: "quiltix.QuiltiXWindow"):
+    # I am printing the QuiltiXWindow
+    print(editor)
+```
+
+You also need to implement a `plugin_name` function returning the name of your plugin. Example:
+```python
+def plugin_name() -> str:
+    return "QuiltiXWindow printer"
+```
+
+If your plugin has the possibility to not be valid (due to missing dependencies or similar) you can implement a `is_valid` function returning `False` to avoid it loading entirely. Example:
+```python
+def is_valid() -> bool:
+    return has_materialxjson
+  ```
+
+For further reference please take a look at the `sample_plugins` dir and the tests in `tests/test_plugins.py`
+
+### QuiltiX Plugin hooks
+These are the hooks that are currently supported, but there is no harm in adding more. If you would like to add hooks in other parts of QuiltiX to support your features, please open an Issue/PR. 
+The hook specifications live in `src/QuiltiX/qx_plugin.py`
+| hook | Purpose |
+|-|-|
+| before_ui_init | Building UI funcionality on top of the QuiltiX UI |
+| after_ui_init | Adjusting parts of the internals before the QuiltiX UI startup |
+| before_mx_import | Adjusting things like environment variables before MaterialX gets initialized |
+| after_mx_import | Adjusting MaterialX specific functionality right after it gets imported |
+| before_pxr_import | Adjusting things like environment variables before pxr (OpenUSD) gets initialized |
+| after_pxr_import | Adjusting pxr (OpenUSD) specific functionality right after it gets imported |
+
 
 ## Integrating with your environment
 QuiltiX tries to rely as much as possible on pre-existing environment variables from MaterialX/USD to extend its systems.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ dependencies = [
     "PyOpenGL",
     "PyOpenGL_accelerate",
     # "OpenUSD_build @ git+https://github.com/PrismPipeline/OpenUSD_build.git@24.03-win-mtlx-1.38.9"
-    # TODO
     "NodeGraphQt-QuiltiX-fork~=0.7",
 ]
 
@@ -43,21 +42,17 @@ dev = [
     "pytest",
     "pytest-qt",
     "pytest-cov",
-    # TODO
     # "MaterialX-stubs @ git+https://github.com/manuelkoester/MaterialX-stubs.git@7696cbb"
 ]
 plugins = [
+    "pygments",
     "materialxjson"
 ]
 
-
-# TODO
-# usd = [
-# ]
-
-# TODO
-# materialx = [
-# ]
+all = [
+    "QuiltiX[dev]",
+    "QuiltiX[plugins]",
+]
 
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,8 @@ addopts = "--cov=QuiltiX"
 testpaths = [
     "tests",
 ]
+log_cli=true
+log_level="DEBUG"
 
 [tool.isort]
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
 ]
 
 dependencies = [
+    "pluggy",
     "materialx==1.38.9",
     "QtPy",
     "PySide6~=6.6",
@@ -45,6 +46,10 @@ dev = [
     # TODO
     # "MaterialX-stubs @ git+https://github.com/manuelkoester/MaterialX-stubs.git@7696cbb"
 ]
+plugins = [
+    "materialxjson"
+]
+
 
 # TODO
 # usd = [

--- a/sample_plugins/materialjson/plugin.py
+++ b/sample_plugins/materialjson/plugin.py
@@ -1,11 +1,15 @@
-#
 # Sample plug-in for QuiltiX which adds import, export, and preview functionality for MaterialX in JSON format
-#    
-import logging, os
-from qtpy import QtCore # type: ignore
+
+import logging
+import os
+from typing import TYPE_CHECKING
+
+from qtpy import QtCore  # type: ignore
 from qtpy.QtWidgets import (  # type: ignore
     QAction,
-    QTextEdit )
+    QTextEdit,
+)
+from QuiltiX import constants, qx_plugin
 
 logger = logging.getLogger(__name__)
 
@@ -14,12 +18,15 @@ try:
 except ImportError:
     logger.error("materialxjson.core not found")
 
-class QuiltiX_JSON_serializer():
+if TYPE_CHECKING:
+    from QuiltiX import quiltix
 
+
+class QuiltiX_JSON_serializer:
     def __init__(self, editor, root):
-        '''
+        """
         Initialize the JSON serializer.
-        '''
+        """
         self.editor = editor
         self.root = root
         self.indent = 4
@@ -41,41 +48,43 @@ class QuiltiX_JSON_serializer():
 
         # Show JSON text. Does most of export, except does not write to file
         show_json_text = QAction("Show as JSON...", editor)
-        show_json_text.triggered.connect(self.show_json_triggered)
-        gltfMenu.addAction(show_json_text)        
+        editor.show_json_triggered = self.show_json_triggered
+        show_json_text.triggered.connect(editor.show_json_triggered)
+        # show_json_text.triggered.connect(self.show_json_triggered)
+        gltfMenu.addAction(show_json_text)
 
-    def set_indent(self, indent): 
-        '''
+    def set_indent(self, indent):
+        """
         Set the indent for the JSON output.
-        '''
+        """
         self.indent = indent
 
     def get_json_from_graph(self):
-        '''
+        """
         Get the JSON for the given MaterialX document.
-        '''
+        """
         doc = self.editor.qx_node_graph.get_current_mx_graph_doc()
         if doc:
             exporter = jsoncore.MaterialXJson()
             json_result = exporter.documentToJSON(doc)
-            return json_result 
+            return json_result
         return None
 
     def show_json_triggered(self):
-        '''
+        """
         Show the current USD Stage.
-        '''
-        json_result = self.get_json_from_graph() 
+        """
+        json_result = self.get_json_from_graph()
 
         # Write JSON UI text box
         if json_result:
             text = jsoncore.Util.jsonToJSONString(json_result, self.indent)
-            self.show_text_box(text, 'JSON Representation')
+            self.show_text_box(text, "JSON Representation")
 
-    def export_json_triggered(self):
-        '''
+    def export_json_triggered(self, editor):
+        """
         Export the current graph to a JSON file.
-        '''
+        """
         start_path = self.editor.mx_selection_path
         if not start_path:
             start_path = self.editor.geometry_selection_path
@@ -84,26 +93,29 @@ class QuiltiX_JSON_serializer():
             start_path = os.path.join(self.root, "resources", "materials")
 
         path = self.editor.request_filepath(
-            title="Save JSON file", start_path=start_path, file_filter="JSON files (*.json)", mode="save",
+            title="Save JSON file",
+            start_path=start_path,
+            file_filter="JSON files (*.json)",
+            mode="save",
         )
 
         if not path:
             return
 
-        json_result = self.get_json_from_graph() 
+        json_result = self.get_json_from_graph()
 
         # Write JSON to file
         if json_result:
-            with open(path, 'w') as outfile:
+            with open(path, "w"):
                 jsoncore.Util.writeJson(json_result, path, 2)
-                logger.info('Wrote JSON file: ' + path)
+                logger.info("Wrote JSON file: " + path)
 
         self.editor.set_current_filepath(path)
 
-    def import_json_triggered(self):
-        '''
+    def import_json_triggered(self, editor):
+        """
         Import a JSON file into the current graph.
-        '''
+        """
         start_path = self.editor.mx_selection_path
         if not start_path:
             start_path = self.editor.geometry_selection_path
@@ -112,25 +124,28 @@ class QuiltiX_JSON_serializer():
             start_path = os.path.join(self.root, "resources", "materials")
 
         path = self.editor.request_filepath(
-            title="Load JSON file", start_path=start_path, file_filter="JSON files (*.json)", mode="open",
+            title="Load JSON file",
+            start_path=start_path,
+            file_filter="JSON files (*.json)",
+            mode="open",
         )
 
         if not os.path.exists(path):
-            logger.error('Cannot find input file: ' + path)
+            logger.error("Cannot find input file: " + path)
             return
 
-        doc = jsoncore.Util.jsonFileToXml(path) 
+        doc = jsoncore.Util.jsonFileToXml(path)
         if doc:
-            logger.info('Loaded JSON file: ' + path)
+            logger.info("Loaded JSON file: " + path)
             self.editor.mx_selection_path = path
             self.editor.qx_node_graph.load_graph_from_mx_doc(doc)
             self.editor.qx_node_graph.mx_file_loaded.emit(path)
 
     # Helper functions
     def show_text_box(self, text, title=""):
-        '''
+        """
         Show a text box with the given text.
-        '''
+        """
         te_text = QTextEdit()
         te_text.setText(text)
         te_text.setReadOnly(True)
@@ -139,15 +154,11 @@ class QuiltiX_JSON_serializer():
         te_text.resize(1000, 800)
         te_text.show()
 
-def install_plugin(editor, root, result):
-    '''
-    Plugin entry point.
-    '''
-    if not jsoncore:
-        logger.error("MaterialX JSON plugin not installed")
-        return [None, None]
-    
-    plugin = QuiltiX_JSON_serializer(editor, root)
 
-    result.plugin = plugin
-    result.id = "MaterialX JSON Serializer"
+@qx_plugin.hookimpl
+def after_ui_init(editor: "quiltix.QuiltiXWindow"):
+    editor.json_serializer = QuiltiX_JSON_serializer(editor, constants.ROOT)
+
+
+def plugin_id() -> str:
+    return "MaterialX JSON Serializer"

--- a/sample_plugins/materialjson/plugin.py
+++ b/sample_plugins/materialjson/plugin.py
@@ -48,9 +48,7 @@ class QuiltiX_JSON_serializer:
 
         # Show JSON text. Does most of export, except does not write to file
         show_json_text = QAction("Show as JSON...", editor)
-        editor.show_json_triggered = self.show_json_triggered
-        show_json_text.triggered.connect(editor.show_json_triggered)
-        # show_json_text.triggered.connect(self.show_json_triggered)
+        show_json_text.triggered.connect(self.show_json_triggered)
         gltfMenu.addAction(show_json_text)
 
     def set_indent(self, indent):

--- a/sample_plugins/materialjson/plugin.py
+++ b/sample_plugins/materialjson/plugin.py
@@ -12,11 +12,13 @@ from qtpy.QtWidgets import (  # type: ignore
 from QuiltiX import constants, qx_plugin
 
 logger = logging.getLogger(__name__)
+have_jsoncore = True
 
 try:
     import materialxjson.core as jsoncore
 except ImportError:
-    logger.error("materialxjson.core not found")
+    have_jsoncore = False
+    logger.error("materialxjso package is not installed")
 
 if TYPE_CHECKING:
     from QuiltiX import quiltix
@@ -61,6 +63,9 @@ class QuiltiX_JSON_serializer:
         """
         Get the JSON for the given MaterialX document.
         """
+        if not have_jsoncore:
+            return None
+
         doc = self.editor.qx_node_graph.get_current_mx_graph_doc()
         if doc:
             exporter = jsoncore.MaterialXJson()
@@ -72,6 +77,10 @@ class QuiltiX_JSON_serializer:
         """
         Show the current USD Stage.
         """
+        if not have_jsoncore:
+            logger.error("materialxjson package is not installed")
+            return
+
         json_result = self.get_json_from_graph()
 
         # Write JSON UI text box
@@ -83,6 +92,10 @@ class QuiltiX_JSON_serializer:
         """
         Export the current graph to a JSON file.
         """
+        if not have_jsoncore:
+            logger.error("materialxjson package is not installed")
+            return
+
         start_path = self.editor.mx_selection_path
         if not start_path:
             start_path = self.editor.geometry_selection_path
@@ -114,6 +127,10 @@ class QuiltiX_JSON_serializer:
         """
         Import a JSON file into the current graph.
         """
+        if not have_jsoncore:
+            logger.error("materialxjson package is not installed")
+            return
+
         start_path = self.editor.mx_selection_path
         if not start_path:
             start_path = self.editor.geometry_selection_path
@@ -155,8 +172,15 @@ class QuiltiX_JSON_serializer:
 
 @qx_plugin.hookimpl
 def after_ui_init(editor: "quiltix.QuiltiXWindow"):
-    editor.json_serializer = QuiltiX_JSON_serializer(editor, constants.ROOT)
-
+    if have_jsoncore:
+        editor.json_serializer = QuiltiX_JSON_serializer(editor, constants.ROOT)
+    else:
+        editor.json_serializer = None
 
 def plugin_id() -> str:
-    return "MaterialX JSON Serializer"
+    if have_jsoncore:
+        return "MaterialX JSON Serializer"
+    return ""
+
+def is_valid() -> bool:
+    return have_jsoncore

--- a/sample_plugins/materialjson/plugin.py
+++ b/sample_plugins/materialjson/plugin.py
@@ -75,7 +75,7 @@ class QuiltiX_JSON_serializer:
 
     def show_json_triggered(self):
         """
-        Show the current USD Stage.
+        Show the current JSON text in a text box.
         """
         if not have_jsoncore:
             logger.error("materialxjson package is not installed")

--- a/sample_plugins/materialjson/plugin.py
+++ b/sample_plugins/materialjson/plugin.py
@@ -1,0 +1,153 @@
+#
+# Sample plug-in for QuiltiX which adds import, export, and preview functionality for MaterialX in JSON format
+#    
+import logging, os
+from qtpy import QtCore # type: ignore
+from qtpy.QtWidgets import (  # type: ignore
+    QAction,
+    QTextEdit )
+
+logger = logging.getLogger(__name__)
+
+try:
+    import materialxjson.core as jsoncore
+except ImportError:
+    logger.error("materialxjson.core not found")
+
+class QuiltiX_JSON_serializer():
+
+    def __init__(self, editor, root):
+        '''
+        Initialize the JSON serializer.
+        '''
+        self.editor = editor
+        self.root = root
+        self.indent = 4
+
+        # Add JSON menu to the file menu
+        # ----------------------------------------
+        editor.file_menu.addSeparator()
+        gltfMenu = editor.file_menu.addMenu("JSON")
+
+        # Export JSON item
+        export_json = QAction("Save JSON...", editor)
+        export_json.triggered.connect(self.export_json_triggered)
+        gltfMenu.addAction(export_json)
+
+        # Import JSON item
+        import_json = QAction("Load JSON...", editor)
+        import_json.triggered.connect(self.import_json_triggered)
+        gltfMenu.addAction(import_json)
+
+        # Show JSON text. Does most of export, except does not write to file
+        show_json_text = QAction("Show as JSON...", editor)
+        show_json_text.triggered.connect(self.show_json_triggered)
+        gltfMenu.addAction(show_json_text)        
+
+    def set_indent(self, indent): 
+        '''
+        Set the indent for the JSON output.
+        '''
+        self.indent = indent
+
+    def get_json_from_graph(self):
+        '''
+        Get the JSON for the given MaterialX document.
+        '''
+        doc = self.editor.qx_node_graph.get_current_mx_graph_doc()
+        if doc:
+            exporter = jsoncore.MaterialXJson()
+            json_result = exporter.documentToJSON(doc)
+            return json_result 
+        return None
+
+    def show_json_triggered(self):
+        '''
+        Show the current USD Stage.
+        '''
+        json_result = self.get_json_from_graph() 
+
+        # Write JSON UI text box
+        if json_result:
+            text = jsoncore.Util.jsonToJSONString(json_result, self.indent)
+            self.show_text_box(text, 'JSON Representation')
+
+    def export_json_triggered(self):
+        '''
+        Export the current graph to a JSON file.
+        '''
+        start_path = self.editor.mx_selection_path
+        if not start_path:
+            start_path = self.editor.geometry_selection_path
+
+        if not start_path:
+            start_path = os.path.join(self.root, "resources", "materials")
+
+        path = self.editor.request_filepath(
+            title="Save JSON file", start_path=start_path, file_filter="JSON files (*.json)", mode="save",
+        )
+
+        if not path:
+            return
+
+        json_result = self.get_json_from_graph() 
+
+        # Write JSON to file
+        if json_result:
+            with open(path, 'w') as outfile:
+                jsoncore.Util.writeJson(json_result, path, 2)
+                logger.info('Wrote JSON file: ' + path)
+
+        self.editor.set_current_filepath(path)
+
+    def import_json_triggered(self):
+        '''
+        Import a JSON file into the current graph.
+        '''
+        start_path = self.editor.mx_selection_path
+        if not start_path:
+            start_path = self.editor.geometry_selection_path
+
+        if not start_path:
+            start_path = os.path.join(self.root, "resources", "materials")
+
+        path = self.editor.request_filepath(
+            title="Load JSON file", start_path=start_path, file_filter="JSON files (*.json)", mode="open",
+        )
+
+        if not os.path.exists(path):
+            logger.error('Cannot find input file: ' + path)
+            return
+
+        doc = jsoncore.Util.jsonFileToXml(path) 
+        if doc:
+            logger.info('Loaded JSON file: ' + path)
+            self.editor.mx_selection_path = path
+            self.editor.qx_node_graph.load_graph_from_mx_doc(doc)
+            self.editor.qx_node_graph.mx_file_loaded.emit(path)
+
+    # Helper functions
+    def show_text_box(self, text, title=""):
+        '''
+        Show a text box with the given text.
+        '''
+        te_text = QTextEdit()
+        te_text.setText(text)
+        te_text.setReadOnly(True)
+        te_text.setParent(self.editor, QtCore.Qt.Window)
+        te_text.setWindowTitle(title)
+        te_text.resize(1000, 800)
+        te_text.show()
+
+def install_plugin(editor, root, result):
+    '''
+    Plugin entry point.
+    '''
+    if not jsoncore:
+        logger.error("MaterialX JSON plugin not installed")
+        return [None, None]
+    
+    plugin = QuiltiX_JSON_serializer(editor, root)
+
+    result.plugin = plugin
+    result.id = "MaterialX JSON Serializer"

--- a/sample_plugins/materialxjson/plugin.py
+++ b/sample_plugins/materialxjson/plugin.py
@@ -12,13 +12,13 @@ from qtpy.QtWidgets import (  # type: ignore
 from QuiltiX import constants, qx_plugin
 
 logger = logging.getLogger(__name__)
-have_jsoncore = True
+has_materialxjsoncore = True
 
 try:
     import materialxjson.core as jsoncore
 except ImportError:
-    have_jsoncore = False
-    logger.error("materialxjso package is not installed")
+    has_materialxjsoncore = False
+    logger.error("materialxjson.core module not found")
 
 if TYPE_CHECKING:
     from QuiltiX import quiltix
@@ -63,9 +63,6 @@ class QuiltiX_JSON_serializer:
         """
         Get the JSON for the given MaterialX document.
         """
-        if not have_jsoncore:
-            return None
-
         doc = self.editor.qx_node_graph.get_current_mx_graph_doc()
         if doc:
             exporter = jsoncore.MaterialXJson()
@@ -75,12 +72,8 @@ class QuiltiX_JSON_serializer:
 
     def show_json_triggered(self):
         """
-        Show the current JSON text in a text box.
+        Show the JSON for the current MaterialX document.
         """
-        if not have_jsoncore:
-            logger.error("materialxjson package is not installed")
-            return
-
         json_result = self.get_json_from_graph()
 
         # Write JSON UI text box
@@ -92,10 +85,6 @@ class QuiltiX_JSON_serializer:
         """
         Export the current graph to a JSON file.
         """
-        if not have_jsoncore:
-            logger.error("materialxjson package is not installed")
-            return
-
         start_path = self.editor.mx_selection_path
         if not start_path:
             start_path = self.editor.geometry_selection_path
@@ -127,10 +116,6 @@ class QuiltiX_JSON_serializer:
         """
         Import a JSON file into the current graph.
         """
-        if not have_jsoncore:
-            logger.error("materialxjson package is not installed")
-            return
-
         start_path = self.editor.mx_selection_path
         if not start_path:
             start_path = self.editor.geometry_selection_path
@@ -172,15 +157,12 @@ class QuiltiX_JSON_serializer:
 
 @qx_plugin.hookimpl
 def after_ui_init(editor: "quiltix.QuiltiXWindow"):
-    if have_jsoncore:
-        editor.json_serializer = QuiltiX_JSON_serializer(editor, constants.ROOT)
-    else:
-        editor.json_serializer = None
+    editor.json_serializer = QuiltiX_JSON_serializer(editor, constants.ROOT)
 
-def plugin_id() -> str:
-    if have_jsoncore:
-        return "MaterialX JSON Serializer"
-    return ""
+
+def plugin_name() -> str:
+    return "MaterialX JSON Serializer"
+
 
 def is_valid() -> bool:
-    return have_jsoncore
+    return has_materialxjsoncore

--- a/sample_plugins/materialxjson/plugin.py
+++ b/sample_plugins/materialxjson/plugin.py
@@ -157,6 +157,8 @@ class QuiltiX_JSON_serializer:
             file_filter="JSON files (*.json)",
             mode="open",
         )
+        if not path:
+            return
 
         if not os.path.exists(path):
             logger.error("Cannot find input file: " + path)

--- a/src/QuiltiX/quiltix.py
+++ b/src/QuiltiX/quiltix.py
@@ -1,47 +1,52 @@
-import os
-import sys
-import subprocess
-import webbrowser
+# ruff: noqa: E402 || due to the plugin manager execution
 import logging
+import os
+import subprocess
+import sys
+import webbrowser
 from importlib import metadata
+
+# Setup plugin manager here before we import a lot of the modules
+from QuiltiX import qx_plugin
+
+plugin_manager = qx_plugin.QuiltiXPluginManager("QuiltiX")
+plugin_manager.load_plugins_from_environment_variable()
+plugin_manager.add_hookspecs(qx_plugin.QuiltixHookspecs)
+
+plugin_manager.hook.before_mx_import()
+
+import MaterialX as mx
+
+
+plugin_manager.hook.before_pxr_import()
+from pxr import Usd, UsdShade
 
 from qtpy import QtCore, QtGui, QtWidgets  # type: ignore
 from qtpy.QtWidgets import (  # type: ignore
     QAction,
     QActionGroup,
-    QMenu,
-    QDockWidget,
-    QMainWindow,
-    QFileDialog,
     QApplication,
-    QTextEdit,
-    QMessageBox,
+    QComboBox,
     QDialog,
+    QDialogButtonBox,
+    QDockWidget,
+    QFileDialog,
+    QGridLayout,
     QLabel,
     QLineEdit,
+    QMainWindow,
+    QMenu,
+    QMessageBox,
     QPushButton,
-    QDialogButtonBox,
-    QGridLayout,
-    QVBoxLayout,
     QSizePolicy,
-    QComboBox,
+    QTextEdit,
+    QVBoxLayout,
 )
 
-from pxr import UsdShade, Usd
-from pxr.Usdviewq.stageView import StageView # type: ignore
-import MaterialX as mx
-
-from QuiltiX import usd_render_settings
-from QuiltiX import usd_stage
-from QuiltiX import usd_stage_tree
-from QuiltiX import usd_stage_view
-from QuiltiX import qx_node
-from QuiltiX import mx_node
+from QuiltiX import mx_node, qx_node, usd_render_settings, usd_stage, usd_stage_tree, usd_stage_view
 from QuiltiX.constants import ROOT
 from QuiltiX.qx_node_property import PropertiesBinWidget
 from QuiltiX.qx_nodegraph import QxNodeGraph
-from QuiltiX.qx_plugin import QuiltiXPluginManager
-
 
 logging.basicConfig()
 logging.root.setLevel("DEBUG")
@@ -57,6 +62,9 @@ class QuiltiXWindow(QMainWindow):
         self.geometry_selection_path = ""
         self.hdri_selection_path = ""
         self.viewer_enabled = True
+
+        plugin_manager.hook.before_ui_init(editor=self)
+
         self.stage_ctrl = usd_stage.MxStageController(self)
 
         quiltix_logo_path = os.path.join(ROOT, "resources", "icons", "quiltix-logo-x.png")
@@ -65,8 +73,7 @@ class QuiltiXWindow(QMainWindow):
         self.init_ui()
         self.init_menu_bar()
 
-        self.plugin_manaager = QuiltiXPluginManager(self, ROOT)
-        self.plugin_manaager.install_plugins()
+        plugin_manager.hook.after_ui_init(editor=self)
 
         if load_style_sheet:
             self.loadStylesheet()

--- a/src/QuiltiX/quiltix.py
+++ b/src/QuiltiX/quiltix.py
@@ -40,6 +40,7 @@ from QuiltiX import mx_node
 from QuiltiX.constants import ROOT
 from QuiltiX.qx_node_property import PropertiesBinWidget
 from QuiltiX.qx_nodegraph import QxNodeGraph
+from QuiltiX.qx_plugin import QuiltiXPluginManager
 
 
 logging.basicConfig()
@@ -63,6 +64,9 @@ class QuiltiXWindow(QMainWindow):
         self.setWindowIcon(quiltix_icon)
         self.init_ui()
         self.init_menu_bar()
+
+        self.plugin_manaager = QuiltiXPluginManager(self, ROOT)
+        self.plugin_manaager.install_plugins()
 
         if load_style_sheet:
             self.loadStylesheet()

--- a/src/QuiltiX/qx_plugin.py
+++ b/src/QuiltiX/qx_plugin.py
@@ -76,7 +76,7 @@ class QuiltiXPluginManager(pluggy.PluginManager):
 
     def load_plugins_from_environment_variable(self, environment_variable: str = PLUGINS_ENV_VAR):
         env_value: str = os.getenv(environment_variable, "")
-        env_values: List[str] = [i for i in env_value.split(";") if i]
+        env_values: List[str] = [i for i in env_value.split(os.pathsep) if i]
         if not env_values:
             return
 

--- a/src/QuiltiX/qx_plugin.py
+++ b/src/QuiltiX/qx_plugin.py
@@ -2,7 +2,7 @@ import importlib.util
 import logging
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Union
+from typing import TYPE_CHECKING, Any, List, Union
 
 import pluggy
 
@@ -10,9 +10,16 @@ if TYPE_CHECKING:
     from QuiltiX import quiltix
 
 
-PLUGINS_ENV_VAR = "QUILTIX_PLUGIN_FOLDER"
-PLUGIN_FILE_NAME = "plugin"
-PLUGIN_ID_FUNCTION_NAME = "plugin_id"
+# The environment variable that contains the paths to the plugins
+PLUGINS_ENV_VAR = "QUILTIX_PLUGIN_PATHS"
+
+# The name of the plugin file
+PLUGIN_FILE_NAME = "plugin"  # .py
+
+# Necessary function name by each plugin to implement and return a QuiltiXPlugin instance
+PLUGIN_NAME_FUNCTION_NAME = "plugin_name"
+
+# If a plugin decides it can be invalid (e.g. missing dependencies), it can implement this function
 PLUGIN_VALID_FUNCTION_NAME = "is_valid"
 
 logger = logging.getLogger(__name__)
@@ -23,77 +30,73 @@ PathOrStr = Union[Path, str]
 
 
 class QuiltiXPluginManager(pluggy.PluginManager):
-    def load_plugins_from_dir(self, plugin_root_dir: PathOrStr):
-        if not os.path.isdir(plugin_root_dir):
-            raise FileNotFoundError(f"Plugin dir: '{plugin_root_dir}' does not exist.")
+    def load_plugins_from_dir(self, plugin_dir: PathOrStr):
+        """
+        Load all plugins from a directory. Each plugin is expected to have a `plugin.py` file in the root of the
+        directory. The `plugin.py` file should contain a function named `plugin_id` that returns a QuiltiXPlugin
+        instance.
+        """
+        # Check for the presence of plugin.py in the subfolder
+        plugin_file = plugin_dir / "plugin.py"
+        if not plugin_file.exists():
+            logger.warning(f"Plugin file not found at {plugin_file}")
+            return
 
-        plugin_root_dir = Path(plugin_root_dir)
-        for dir in plugin_root_dir.iterdir():
-            if not dir.is_dir():
-                continue
+        module_name = f"{str(plugin_dir)}.plugin"
+        spec = importlib.util.spec_from_file_location(module_name, plugin_file)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
 
-            # Check for the presence of plugin.py in the subfolder
-            plugin_file = dir / "plugin.py"
-            if not plugin_file.is_file():
-                continue
+        # Check for necessary presence of PLUGIN_NAME_FUNCTION_NAME function
+        # and skip if it does not exist or does not return a string
+        if hasattr(module, PLUGIN_NAME_FUNCTION_NAME):
+            plugin_name_function = getattr(module, PLUGIN_NAME_FUNCTION_NAME)
+            plugin_name: Any = plugin_name_function()
+            if not isinstance(plugin_name, str):
+                logger.warning(f"Plugin name {plugin_name} is not valid. Skipping plugin at {module.__file__}")
+                return
+        else:
+            logger.warning(
+                f"Found plugin at {module.__file__}, but i does not have a '{PLUGIN_NAME_FUNCTION_NAME}' function."
+            )
+            return
 
-            module_name = f"{str(dir)}.plugin"
-            spec = importlib.util.spec_from_file_location(module_name, plugin_file)
-            module = importlib.util.module_from_spec(spec)
-            spec.loader.exec_module(module)
+        # Check for presence of PLUGIN_VALID_FUNCTION_NAME function and skip if it returns False
+        if hasattr(module, PLUGIN_VALID_FUNCTION_NAME):
+            plugin_valid_function = getattr(module, PLUGIN_VALID_FUNCTION_NAME)
+            if not plugin_valid_function():
+                logger.warning(f"Plugin {plugin_name} is not valid. Skipping plugin at {module.__file__}")
+                return
 
-            # Check validity of plugin after loading
-            is_valid = True
-            if hasattr(module, PLUGIN_VALID_FUNCTION_NAME):
-                plugin_valid_function = getattr(module, PLUGIN_VALID_FUNCTION_NAME)
-                if not plugin_valid_function():
-                    logger.warning(
-                        f"Found plugin at {module.__file__}, but it is not valid for loading."
-                    )
-                    is_valid = False
-            else:
-                logger.warning(
-                    f"Found plugin at {module.__file__}, but it does not have a '{PLUGIN_VALID_FUNCTION_NAME}' function."                
-                )                
-                is_valid = False                
-
-            if is_valid:
-                # Check for presence of PLUGIN_ID_FUNCTION_NAME function
-                if hasattr(module, PLUGIN_ID_FUNCTION_NAME):
-                    plugin_id_function = getattr(module, PLUGIN_ID_FUNCTION_NAME)
-                    plugin_id_name = plugin_id_function()
-                    if plugin_id_function and len(plugin_id_name) > 0:
-                        self.register(module, plugin_id_name)
-                        logger.info(f"Registered plugin '{plugin_id_name} at {module.__file__}")
-                    else:
-                        logger.warning(
-                            f"Found plugin at {module.__file__}, but has an invalid identifier '{plugin_id_name}'."
-                        )
-                else:
-                    logger.warning(
-                        f"Found plugin at {module.__file__}, but it does not have a '{PLUGIN_ID_FUNCTION_NAME}' function."
-                    )
+        try:
+            self.register(module, plugin_name)
+            logger.info(f"Registered plugin '{plugin_name} at {module.__file__}")
+        except ValueError:
+            logger.warning(f"Plugin with name '{plugin_name}' already registered. Skipping plugin at {module.__file__}")
 
     def load_plugins_from_environment_variable(self, environment_variable: str = PLUGINS_ENV_VAR):
+        """
+        Loop through an environment variable and load all plugins from the directories specified in the environment.
+        """
         env_value: str = os.getenv(environment_variable, "")
-        env_values: List[str] = [i for i in env_value.split(os.pathsep) if i]
+        env_values: List[str] = [env_value for env_value in env_value.split(os.pathsep) if env_value]
         if not env_values:
             return
 
-        plugin_root_dirs: List[Path] = [Path(i) for i in env_values if Path(i).is_dir()]
+        plugin_root_dirs: List[Path] = [Path(env_value) for env_value in env_values if Path(env_value).is_dir()]
         for plugin_root_dir in plugin_root_dirs:
             self.load_plugins_from_dir(plugin_root_dir)
 
 
 class QuiltixHookspecs:
     @hookspec
-    def after_ui_init(self, editor: "quiltix.QuiltiXWindow"):
+    def before_ui_init(self, editor: "quiltix.QuiltiXWindow"):
         """
         :param editor: The QuiltiX Window
         """
 
     @hookspec
-    def before_ui_init(self, editor: "quiltix.QuiltiXWindow"):
+    def after_ui_init(self, editor: "quiltix.QuiltiXWindow"):
         """
         :param editor: The QuiltiX Window
         """
@@ -102,10 +105,24 @@ class QuiltixHookspecs:
     def before_mx_import(self):
         """
         This allows any code to execute before MaterialX gets imported
+        Useful for adjusting environment variables before MaterialX gets imported
+        """
+
+    @hookspec
+    def after_mx_import(self):
+        """
+        This allows any code to execute after MaterialX gets imported
         """
 
     @hookspec
     def before_pxr_import(self):
+        """
+        This allows any code to execute before OpenUSD's pxr gets imported
+        Useful for adjusting environment variables before pxr gets imported
+        """
+
+    @hookspec
+    def after_pxr_import(self):
         """
         This allows any code to execute before OpenUSD's pxr gets imported
         """

--- a/src/QuiltiX/qx_plugin.py
+++ b/src/QuiltiX/qx_plugin.py
@@ -1,0 +1,61 @@
+import importlib.util, os, logging
+
+logger = logging.getLogger(__name__)
+
+class QuiltiXPlugin():
+    def __init__(self):
+        self.id = ""
+        self.plugin = None
+
+class QuiltiXPluginManager():
+    def __init__(self, editor, root):
+        self.editor = editor
+        self.root = root
+        self.plugins = []
+
+    def install_plugins(self):
+        self.plugins = []
+        plugin_roots = [os.path.join(self.root, "plugins"), os.getenv("QUILTIX_PLUGIN_FOLDER", "")]
+        for plugin_folder in plugin_roots:
+            if os.path.exists(plugin_folder):
+                absolute_plugin_folder = os.path.abspath(plugin_folder)
+                logger.debug(f"Loading plugin from {absolute_plugin_folder}...")                
+                self.install_plugins_from_folder(plugin_folder)
+
+    def install_plugins_from_folder(self, plugin_folder):
+        if not os.path.isdir(plugin_folder):
+            logger.warning(f"Plugin folder {plugin_folder} not found.")
+            return
+        
+        # Get the list of all subfolders in the plugin_folder
+        for entry in os.listdir(plugin_folder):
+            entry_path = os.path.join(plugin_folder, entry)
+
+            if os.path.isdir(entry_path):
+                # Check for the presence of plugin.py in the subfolder
+                plugin_file = os.path.join(entry_path, 'plugin.py')
+                if os.path.isfile(plugin_file):
+                    module_name = f"{entry}.plugin"
+
+                    # Dynamically import the module
+                    spec = importlib.util.spec_from_file_location(module_name, plugin_file)
+                    module = importlib.util.module_from_spec(spec)
+                    spec.loader.exec_module(module)
+
+                    # Call module install_plugin function if it exists
+                    if hasattr(module, "install_plugin"):
+                        pluginInfo = QuiltiXPlugin()
+                        module.install_plugin(self.editor, self.root, pluginInfo)
+                        if pluginInfo.id and pluginInfo.plugin:
+                            pluginExists = None
+                            for installed_plugin in self.plugins:
+                                if installed_plugin.id == pluginInfo.id:
+                                    pluginExists = installed_plugin
+                                    break   
+                            if pluginExists:
+                                logger.warning(f"Plugin with id {pluginInfo.id} already installed.")
+                            else:
+                                self.plugins.append(pluginInfo)
+                                logger.debug(f"Installed plugin {pluginInfo.id} from {plugin_file}.")
+                    else:
+                        logger.warning(f"No installPlugin function found in {plugin_file}.")    

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
 import pytest
 import helpers
+from pathlib import Path
+from QuiltiX.constants import ROOT
 
 
 @pytest.fixture
@@ -14,3 +16,12 @@ def quiltix_instance(qtbot):
     """
     with helpers.quiltix_instance() as editor:
         yield editor
+
+
+@pytest.fixture
+def materialxjson_plugin():
+    import os
+
+    os.environ["QUILTIX_PLUGIN_PATHS"] = (
+        str((Path(ROOT).parent.parent / "sample_plugins/materialxjson")) + os.pathsep + os.environ.get("QUILTIX_PLUGIN_PATHS", "")
+    )

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -2,7 +2,7 @@ import os
 import sys
 from contextlib import contextmanager
 
-from Qt.QtWidgets import QApplication  # type: ignore
+from qtpy.QtWidgets import QApplication  # type: ignore
 
 from QuiltiX import quiltix
 
@@ -27,7 +27,6 @@ def quiltix_instance(load_shaderball=True, load_default_graph=False):
         load_shaderball=load_shaderball,
         load_default_graph=load_default_graph
     )
-    editor.show()
     yield editor
 
     # The QApplication provided py pytest-qt does not need to be exited

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,4 @@
+def test_load_plugin_materialxjson(materialxjson_plugin, quiltix_instance):
+    assert quiltix_instance.json_serializer
+    assert "mimetype" in quiltix_instance.json_serializer.get_json_from_graph()
+    assert quiltix_instance.json_serializer.get_json_from_graph()["mimetype"] == "application/mtlx+json"


### PR DESCRIPTION
## Proposal

This is an initial proposed design for allow users to create compartmentalized plug-ins without having to override the main Qt application.

## Design
- Add in a simple `QuiltiXPlugin` class.  For now this has the minimal of:
  - An identifier string
  - The plugin handler
- Add in a simple `QuiltiXPluginManager` which is just a list of `QuiltiXPlugin`.
- Access is provided to the editor as well as the package ROOT. 
- There are no constraints on what can and cannot be performed as is the case now when overriding the entire application.
- It is up to the implementer to know the UI structure (also no change).

![image](https://github.com/PrismPipeline/QuiltiX/assets/49369885/b709f6ba-4c47-4e90-b1cb-6abe1d4186f8)


### Discovery
- A plugin is contained in a folder with a `plugin.py` file which contains a module with a `install_plugin` entry point.
- One or more of these folders can reside under the following plugin "roots":
  - The `plugins` folder under the root of the Python  distribution.
  - The folder specified by `QUILTIX_PLUGIN_FOLDER`
  
### Example
- I've migrated the JSON MaterialX logic to a `materialxjson` folder under a new `sample_plugins` folder.
- Setting the env variable will allow this plug-in to be loaded.
- The plug-in has read/write to JSON file and a "show as text" menu options. 
![image](https://github.com/PrismPipeline/QuiltiX/assets/49369885/8bc45569-c4b7-47a7-94f1-09a34228b070)

@manuelkoester, @RichardFrangenberg : Let me know what you think of this. It's naturally very basic to start with. 
If something like this is reasonable, I'd like to move on to adding glTF support this way. Thanks!
