### PR TITLE
Add checking for implicit outputs on multioutput nodes on load

### DIFF
--- a/src/QuiltiX/qx_node.py
+++ b/src/QuiltiX/qx_node.py
@@ -125,6 +125,7 @@ class QxNode(QxNodeBase):
             return
 
         self.change_type(mx_def_type)
+        self.complete_outputs_on_mx_node(mx_node)
         self.set_properties_from_mx_node(mx_node)
 
     def add_type_property(self, current_type_name=None):
@@ -423,7 +424,23 @@ class QxNode(QxNodeBase):
         # name = self.get_mx_input_name_from_property_name(name)
         super().create_property(name, value, items, range, widget_type, tab)
 
+    def complete_outputs_on_mx_node(self, mx_node):
+
+        # Handle with node outputs are not explicitly specified on
+        # a multioutput node. Note that this must be done
+        # before the qx_node is created and before connections are made.
+        if mx_node.getType() == "multioutput":
+            mx_node_def = mx_node.getNodeDef()
+            if mx_node_def:
+                for mx_output in mx_node_def.getActiveOutputs():
+                    mx_output_name = mx_output.getName()
+                    if not mx_node.getOutput(mx_output_name):
+                        mx_output_type = mx_output.getType()
+                        mx_node.addOutput(mx_output_name, mx_output_type)
+
+
     def set_properties_from_mx_node(self, mx_node):
+
         for mx_input in mx_node.getActiveInputs():
             mx_input_value = mx_input.getValue()
             mx_input_name = mx_input.getName()

--- a/src/QuiltiX/qx_node.py
+++ b/src/QuiltiX/qx_node.py
@@ -125,7 +125,7 @@ class QxNode(QxNodeBase):
             return
 
         self.change_type(mx_def_type)
-        self.complete_outputs_on_mx_node(mx_node)
+        self.complete_outputs_for_multioutputs(mx_node)
         self.set_properties_from_mx_node(mx_node)
 
     def add_type_property(self, current_type_name=None):
@@ -424,20 +424,23 @@ class QxNode(QxNodeBase):
         # name = self.get_mx_input_name_from_property_name(name)
         super().create_property(name, value, items, range, widget_type, tab)
 
-    def complete_outputs_on_mx_node(self, mx_node):
+    def complete_outputs_for_multioutputs(self, mx_node):
 
         # Handle with node outputs are not explicitly specified on
         # a multioutput node. Note that this must be done
         # before the qx_node is created and before connections are made.
-        if mx_node.getType() == "multioutput":
-            mx_node_def = mx_node.getNodeDef()
-            if mx_node_def:
-                for mx_output in mx_node_def.getActiveOutputs():
-                    mx_output_name = mx_output.getName()
-                    if not mx_node.getOutput(mx_output_name):
-                        mx_output_type = mx_output.getType()
-                        mx_node.addOutput(mx_output_name, mx_output_type)
-
+        if mx_node.getType() != "multioutput":
+            return
+        
+        mx_node_def = mx_node.getNodeDef()
+        if not mx_node_def:
+            return
+        
+        for mx_output in mx_node_def.getActiveOutputs():
+            mx_output_name = mx_output.getName()
+            if not mx_node.getOutput(mx_output_name):
+                mx_output_type = mx_output.getType()
+                mx_node.addOutput(mx_output_name, mx_output_type)
 
     def set_properties_from_mx_node(self, mx_node):
 


### PR DESCRIPTION
## Issue

A node may not have all of it's outputs explicitly specified. If an output connection is specified on a MaterialX node and
the output is not found on the upstream node then a connection will not be made. This affects load.

If you create a node and make a connection then this will not occur since the qx_node populates itself with all the required outputs from the node definition. 

## Change

To perform the same action on the mx_node as the qx_node, some additional logic has been added to add input any missing outputs. This is for now only for `multioutput` nodes as this appears to be the failing case. Note that this does **not** add any additional information not already added on save from the qx_node.

## Test

This is an example glTF imported material. In this case `gltf_colorimage` does not have it's outputs specified so will fail connection before this change.

```xml
<?xml version="1.0"?>
<materialx version="1.39">
  <gltf_pbr name="SciFiHelmet" type="surfaceshader">
    <input name="base_color" type="color3" nodename="image_base_color" output="outcolor" />
    <input name="metallic" type="float" nodename="extract_orm3" />
    <input name="roughness" type="float" nodename="extract_orm2" />
    <input name="occlusion" type="float" nodename="image_occlusion" />
    <input name="normal" type="vector3" nodename="image_normal" />
    <input name="emissive" type="color3" value="0, 0, 0" colorspace="srgb_texture" />
  </gltf_pbr>
  <surfacematerial name="MAT_SciFiHelmet" type="material" xpos="17.391304" ypos="0.000000">
    <input name="surfaceshader" type="surfaceshader" nodename="SciFiHelmet" />
  </surfacematerial>
  <gltf_colorimage name="image_base_color" type="multioutput" xpos="10.144928" ypos="-2.948276">
    <input name="file" type="filename" value="SciFiHelmet_BaseColor.png" colorspace="srgb_texture" fileprefix="" />
  </gltf_colorimage>
  <gltf_image name="image_orm" type="vector3" xpos="6.521739" ypos="6.465517">
    <input name="file" type="filename" value="SciFiHelmet_MetallicRoughness.png" fileprefix="" />
  </gltf_image>
  <extract name="extract_orm" type="float" xpos="9.753623" ypos="5.387931">
    <input name="in" type="vector3" nodename="image_orm" />
    <input name="index" type="integer" value="0" />
  </extract>
  <extract name="extract_orm2" type="float" xpos="10.144928" ypos="0.327586">
    <input name="in" type="vector3" nodename="image_orm" />
    <input name="index" type="integer" value="1" />
  </extract>
  <extract name="extract_orm3" type="float" xpos="10.144928" ypos="-1.310345">
    <input name="in" type="vector3" nodename="image_orm" />
    <input name="index" type="integer" value="2" />
  </extract>
  <gltf_normalmap name="image_normal" type="vector3" xpos="10.144928" ypos="1.956897">
    <input name="file" type="filename" value="SciFiHelmet_Normal.png" fileprefix="" />
  </gltf_normalmap>
  <gltf_image name="image_occlusion" type="float" xpos="10.144928" ypos="3.293103">
    <input name="file" type="filename" value="SciFiHelmet_AmbientOcclusion.png" fileprefix="" />
  </gltf_image>
  <look name="look">
    <materialassign name="MAT_SciFiHelmet" material="MAT_SciFiHelmet" geom="/SciFiHelmet/SciFiHelmet" />
  </look>
</materialx>
```

This is a snapshot after the fix (with the appropriate `base_color` connection being made.
![image](https://github.com/user-attachments/assets/5fd9286c-0468-4a64-87b0-0edb1cd37742)

>Note: The error showing up is not due to this issue but it seems the "auto nodegraph" creation is creating invalid nodegraph outputs. Turing this off removes this error.  