### PR TITLE
Fix for nodegraph creation connections for nodes with multiple outputs

### DIFF
--- a/src/QuiltiX/qx_nodegraph.py
+++ b/src/QuiltiX/qx_nodegraph.py
@@ -620,7 +620,8 @@ class QxNodeGraph(NodeGraphQt.NodeGraph):
                             )
                             mx_node = qx_node_ids_to_mx_nodes[node_id]
                             if mx_node.getType() == "multioutput":
-                                output = mx_node.getActiveOutput(connection["out"][1])
+                                connection_name = f"{output_data['name']}"
+                                output = mx_node.getActiveOutput(connection_name)
                                 main_mx_node_graph_output.setConnectedOutput(output)
                             else:
                                 main_mx_node_graph_output.setConnectedNode(mx_node)


### PR DESCRIPTION
## Issue

- Fixes #87 
- When an output is created on nodegraph creation, it is using the first output name on the upstream node. 

# Change

- Use proper output name when setting nodegraph output's `output` value.
- This is already computed to create the nodegraph output name so simply use that name.

# Test with issue document or this simplified version:
```xml
<?xml version="1.0"?>
<materialx version="1.38">
  <gltf_pbr name="Material_MR" type="surfaceshader" xpos="1.750390625" ypos="-7.68125">
    <input name="base_color" type="color3" value="1, 1, 1" output="outcolor" nodename="image_base_color" />
    <input name="metallic" type="float" value="1" />
    <input name="roughness" type="float" value="1" />
    <input name="occlusion" type="float" value="1" />
    <input name="transmission" type="float" value="0" />
    <input name="specular" type="float" value="1" />
    <input name="specular_color" type="color3" value="1, 1, 1" />
    <input name="ior" type="float" value="1.5" />
    <input name="alpha" type="float" value="1" />
    <input name="alpha_mode" type="integer" value="0" />
    <input name="alpha_cutoff" type="float" value="0.5" />
    <input name="iridescence" type="float" value="0" />
    <input name="iridescence_ior" type="float" value="1.3" />
    <input name="iridescence_thickness" type="float" value="100" />
    <input name="sheen_color" type="color3" value="0, 0, 0" />
    <input name="sheen_roughness" type="float" value="0" />
    <input name="clearcoat" type="float" value="0" />
    <input name="clearcoat_roughness" type="float" value="0" />
    <input name="emissive" type="color3" value="0, 0, 0" />
    <input name="emissive_strength" type="float" value="1" />
    <input name="thickness" type="float" value="0" />
    <input name="attenuation_distance" type="float" value="0" />
    <input name="attenuation_color" type="color3" value="1, 1, 1" />
    <output name="out" type="surfaceshader" />
  </gltf_pbr>
  <surfacematerial name="MAT_Material_MR" type="material" xpos="5.4321875" ypos="-7.68125">
    <input name="surfaceshader" type="surfaceshader" nodename="Material_MR" />
    <output name="out" type="material" />
  </surfacematerial>
  <gltf_colorimage name="image_base_color" type="multioutput" xpos="-2.1281939654008446" ypos="-7.922372774667845">
    <input name="file" type="filename" value="D:/Work/materialx/QuiltiX/media/QuiltiX.png" colorspace="srgb_texture" />
    <input name="default" type="color4" value="0, 0, 0, 0" />
    <input name="pivot" type="vector2" value="0, 1" />
    <input name="scale" type="vector2" value="1, 1" />
    <input name="rotate" type="float" value="0" />
    <input name="offset" type="vector2" value="0, 0" />
    <input name="operationorder" type="integer" value="1" />
    <input name="uaddressmode" type="string" value="periodic" />
    <input name="vaddressmode" type="string" value="periodic" />
    <input name="filtertype" type="string" value="linear" />
    <input name="color" type="color4" value="1, 1, 1, 1" />
    <input name="geomcolor" type="color4" value="1, 1, 1, 1" />
    <output name="outcolor" type="color3" />
    <output name="outa" type="float" />
  </gltf_colorimage>
</materialx>
```
- Load it in and do a "show MaterialX as text" with the nodegraph auto generation option on. 
- The error should no longer occur.
- Output with `outcolor` and `outa` from multioutput upstream nodes connected properly.
```xml
<?xml version="1.0"?>
<materialx version="1.38">
  <nodegraph name="NG_main">
    <gltf_colorimage name="image_base_color" type="multioutput" xpos="-5.36828125" ypos="-7.68125">
      <input name="file" type="filename" value="Default_albedo.jpg" colorspace="srgb_texture" />
      <input name="default" type="color4" value="0, 0, 0, 0" />
      <input name="pivot" type="vector2" value="0, 1" />
      <input name="scale" type="vector2" value="1, 1" />
      <input name="rotate" type="float" value="0" />
      <input name="offset" type="vector2" value="0, 0" />
      <input name="operationorder" type="integer" value="1" />
      <input name="uaddressmode" type="string" value="periodic" />
      <input name="vaddressmode" type="string" value="periodic" />
      <input name="filtertype" type="string" value="linear" />
      <input name="color" type="color4" value="1, 1, 1, 1" />
      <input name="geomcolor" type="color4" value="1, 1, 1, 1" />
      <output name="outcolor" type="color3" />
      <output name="outa" type="float" />
    </gltf_colorimage>
    <gltf_image name="image_orm" type="vector3" xpos="-5.36828125" ypos="-3.11875">
      <input name="file" type="filename" value="Default_metalRoughness.jpg" colorspace="srgb_texture" />
      <input name="default" type="vector3" value="0, 0, 0" />
      <input name="pivot" type="vector2" value="0, 1" />
      <input name="scale" type="vector2" value="1, 1" />
      <input name="rotate" type="float" value="0" />
      <input name="offset" type="vector2" value="0, 0" />
      <input name="operationorder" type="integer" value="0" />
      <input name="uaddressmode" type="string" value="periodic" />
      <input name="vaddressmode" type="string" value="periodic" />
      <input name="filtertype" type="string" value="linear" />
      <output name="out" type="vector3" />
    </gltf_image>
    <extract name="extract_orm" type="float" xpos="-1.880078125" ypos="-7.68125">
      <input name="in" type="vector3" value="0, 0, 0" nodename="image_orm" />
      <input name="index" type="integer" value="0" />
      <output name="out" type="float" />
    </extract>
    <extract name="extract_orm2" type="float" xpos="-1.880078125" ypos="-3.88125">
      <input name="in" type="vector3" value="0, 0, 0" nodename="image_orm" />
      <input name="index" type="integer" value="1" />
      <output name="out" type="float" />
    </extract>
    <extract name="extract_orm3" type="float" xpos="-1.880078125" ypos="-5.78125">
      <input name="in" type="vector3" value="0, 0, 0" nodename="image_orm" />
      <input name="index" type="integer" value="2" />
      <output name="out" type="float" />
    </extract>
    <gltf_normalmap name="image_normal" type="vector3" xpos="-5.36828125" ypos="1.2127499999999998">
      <input name="file" type="filename" value="Default_normal.jpg" colorspace="srgb_texture" />
      <input name="default" type="vector3" value="0.5, 0.5, 1" />
      <input name="pivot" type="vector2" value="0, 1" />
      <input name="scale" type="vector2" value="1, 1" />
      <input name="rotate" type="float" value="0" />
      <input name="offset" type="vector2" value="0, 0" />
      <input name="operationorder" type="integer" value="0" />
      <input name="uaddressmode" type="string" value="periodic" />
      <input name="vaddressmode" type="string" value="periodic" />
      <input name="filtertype" type="string" value="linear" />
      <output name="out" type="vector3" />
    </gltf_normalmap>
    <gltf_image name="image_occlusion" type="float" xpos="-5.36828125" ypos="5.775250000000001">
      <input name="file" type="filename" value="Default_AO.jpg" colorspace="srgb_texture" />
      <input name="factor" type="float" value="1" />
      <input name="default" type="float" value="0" />
      <input name="pivot" type="vector2" value="0, 1" />
      <input name="scale" type="vector2" value="1, 1" />
      <input name="rotate" type="float" value="0" />
      <input name="offset" type="vector2" value="0, 0" />
      <input name="operationorder" type="integer" value="0" />
      <input name="uaddressmode" type="string" value="periodic" />
      <input name="vaddressmode" type="string" value="periodic" />
      <input name="filtertype" type="string" value="linear" />
      <output name="out" type="float" />
    </gltf_image>
    <gltf_colorimage name="image_emissive" type="multioutput" xpos="-5.36828125" ypos="10.68425">
      <input name="file" type="filename" value="Default_emissive.jpg" colorspace="srgb_texture" />
      <input name="default" type="color4" value="0, 0, 0, 0" />
      <input name="pivot" type="vector2" value="0, 1" />
      <input name="scale" type="vector2" value="1, 1" />
      <input name="rotate" type="float" value="0" />
      <input name="offset" type="vector2" value="0, 0" />
      <input name="operationorder" type="integer" value="1" />
      <input name="uaddressmode" type="string" value="periodic" />
      <input name="vaddressmode" type="string" value="periodic" />
      <input name="filtertype" type="string" value="linear" />
      <input name="color" type="color4" value="1, 1, 1, 1" />
      <input name="geomcolor" type="color4" value="1, 1, 1, 1" />
      <output name="outcolor" type="color3" />
      <output name="outa" type="float" />
    </gltf_colorimage>
    <output name="output_image_base_color_outcolor" type="color3" output="outcolor" nodename="image_base_color" />
    <output name="output_image_base_color_outa" type="float" output="outa" nodename="image_base_color" />
    <output name="output_extract_orm2_out" type="float" nodename="extract_orm2" />
    <output name="output_extract_orm3_out" type="float" nodename="extract_orm3" />
    <output name="output_image_normal_out" type="vector3" nodename="image_normal" />
    <output name="output_image_occlusion_out" type="float" nodename="image_occlusion" />
    <output name="output_image_emissive_outcolor" type="color3" output="outcolor" nodename="image_emissive" />
    <output name="output_image_emissive_outa" type="float" output="outa" nodename="image_emissive" />
  </nodegraph>
  <gltf_pbr name="Material_MR" type="surfaceshader" xpos="1.750390625" ypos="-7.68125">
    <input name="base_color" type="color3" value="1, 1, 1" nodegraph="NG_main" output="output_image_base_color_outcolor" />
    <input name="metallic" type="float" value="1" nodegraph="NG_main" output="output_extract_orm3_out" />
    <input name="roughness" type="float" value="1" nodegraph="NG_main" output="output_extract_orm2_out" />
    <input name="normal" type="vector3" nodegraph="NG_main" output="output_image_normal_out" />
    <input name="occlusion" type="float" value="1" nodegraph="NG_main" output="output_image_occlusion_out" />
    <input name="transmission" type="float" value="0" />
    <input name="specular" type="float" value="1" />
    <input name="specular_color" type="color3" value="1, 1, 1" />
    <input name="ior" type="float" value="1.5" />
    <input name="alpha" type="float" value="1" />
    <input name="alpha_mode" type="integer" value="0" />
    <input name="alpha_cutoff" type="float" value="0.5" />
    <input name="iridescence" type="float" value="0" />
    <input name="iridescence_ior" type="float" value="1.3" />
    <input name="iridescence_thickness" type="float" value="100" />
    <input name="sheen_color" type="color3" value="0, 0, 0" />
    <input name="sheen_roughness" type="float" value="0" />
    <input name="clearcoat" type="float" value="0" />
    <input name="clearcoat_roughness" type="float" value="0" />
    <input name="emissive" type="color3" value="0, 0, 0" nodegraph="NG_main" output="output_image_emissive_outcolor" />
    <input name="emissive_strength" type="float" value="1" />
    <input name="thickness" type="float" value="0" />
    <input name="attenuation_distance" type="float" value="0" />
    <input name="attenuation_color" type="color3" value="1, 1, 1" />
    <output name="out" type="surfaceshader" />
  </gltf_pbr>
  <surfacematerial name="MAT_Material_MR" type="material" xpos="5.4321875" ypos="-7.68125">
    <input name="surfaceshader" type="surfaceshader" nodename="Material_MR" />
    <output name="out" type="material" />
  </surfacematerial>
</materialx>
```