### PR TITLE
Resolve filename values on load

### DIFF
--- a/src/QuiltiX/qx_node.py
+++ b/src/QuiltiX/qx_node.py
@@ -458,6 +458,8 @@ class QxNode(QxNodeBase):
                         mx_input_value = [v.strip() for v in mx_input_value.split(",")]
 
                     mx_input_value = tuple(mx_input_value)
+                elif mx_input_type == "filename":
+                    mx_input_value = mx_input.getResolvedValueString()
 
                 property_name = self.get_property_name_from_mx_input(
                     mx_input_name


### PR DESCRIPTION
## Issue

When loading in a document where the input is a filename, the string is not resolved it is possible
that the incorrect path is used. Example cases include:

1. If a `fileprefix` attribute is set on a any parent. The attribute value should be prepended to the file name
2. If there are any tokens, including UDIM tokens, they will not be resolved.

## Fix

Update to use `getResolvedValueString()` for `filename` input types.

### Example

The "wood" sample which comes with the release of MaterialX does not load the correct images since it uses `fileprefix`
The following has the correct image loaded after the code change which prepends the "../../images" path.

![image](https://github.com/user-attachments/assets/527bb4a2-9195-43c4-94d1-0c6ab47d0b02)

It would otherwise render "black".

This is the input file:
```xml
<?xml version="1.0"?>
<materialx version="1.39" colorspace="lin_rec709">
  <nodegraph name="NG_wood1" fileprefix="../../../Images/">
    <tiledimage name="image_color" type="color3">
      <input name="file" type="filename" value="wood_color.jpg" colorspace="srgb_texture" />
      <input name="uvtiling" type="vector2" value="4.0, 4.0" />
    </tiledimage>
    <tiledimage name="image_roughness" type="float">
      <input name="file" type="filename" value="wood_roughness.jpg" />
      <input name="uvtiling" type="vector2" value="4.0, 4.0" />
    </tiledimage>
    <output name="out_color" type="color3" nodename="image_color" />
    <output name="out_roughness" type="float" nodename="image_roughness" />
  </nodegraph>
  <standard_surface name="SR_wood1" type="surfaceshader">
    <input name="base" type="float" value="1" />
    <input name="base_color" type="color3" nodegraph="NG_wood1" output="out_color" />
    <input name="specular" type="float" value="0.4" />
    <input name="specular_roughness" type="float" nodegraph="NG_wood1" output="out_roughness" />
    <input name="specular_anisotropy" type="float" value="0.5" />
    <input name="coat" type="float" value="0.1" />
    <input name="coat_roughness" type="float" value="0.2" />
    <input name="coat_anisotropy" type="float" value="0.5" />
  </standard_surface>
  <surfacematerial name="Tiled_Wood" type="material">
    <input name="surfaceshader" type="surfaceshader" nodename="SR_wood1" />
  </surfacematerial>
</materialx>
```