### PR TITLE
Avoid possible clash of Qt modules with USD

### DIFF
--- a/sample_plugins/materialxjson/plugin.py
+++ b/sample_plugins/materialxjson/plugin.py
@@ -3,6 +3,8 @@
 import logging
 import os
 
+logger = logging.getLogger(__name__)
+
 # Optional syntax highlighting if pygments is installed
 have_highliting = True
 try:
@@ -14,21 +16,28 @@ except ImportError:
 
 from typing import TYPE_CHECKING
 
-from qtpy import QtCore  # type: ignore
-from qtpy.QtWidgets import (  # type: ignore
-    QAction,
-    QTextEdit,
-)
+
+def load_qt_modules():
+    global QtCore, QAction, QTextEdit
+    try:
+        from qtpy import QtCore  # type: ignore
+        from qtpy.QtWidgets import QAction, QTextEdit  # type: ignore
+        logger.info("qtpy modules loaded successfully")
+    except ImportError as e:
+        logger.error(f"Failed to import qtpy modules: {e}")
+        raise
+
 from QuiltiX import constants, qx_plugin
 
-logger = logging.getLogger(__name__)
 has_materialxjsoncore = True
 
 try:
+    #from materialxjson import core as jsoncore
     import materialxjson.core as jsoncore
+    logger.info("materialxjson.core module loaded successfully")
 except ImportError:
     has_materialxjsoncore = False
-    logger.error("materialxjson.core module not found")
+    logger.error("materialxjson.core module failed to load.")
 
 if TYPE_CHECKING:
     from QuiltiX import quiltix
@@ -194,6 +203,7 @@ class QuiltiX_JSON_serializer:
 
 @qx_plugin.hookimpl
 def after_ui_init(editor: "quiltix.QuiltiXWindow"):
+    load_qt_modules()
     editor.json_serializer = QuiltiX_JSON_serializer(editor, constants.ROOT)
 
 

--- a/sample_plugins/materialxjson/plugin.py
+++ b/sample_plugins/materialxjson/plugin.py
@@ -32,7 +32,6 @@ from QuiltiX import constants, qx_plugin
 has_materialxjsoncore = True
 
 try:
-    #from materialxjson import core as jsoncore
     import materialxjson.core as jsoncore
     logger.info("materialxjson.core module loaded successfully")
 except ImportError:


### PR DESCRIPTION
## Changes

Delay loading Qt modules as they appear to clash with USD imports.
Workaround for #103.

## Details

This appears to be the plugin load location:
```
plugin_manager = qx_plugin.QuiltiXPluginManager("QuiltiX")
plugin_manager.load_plugins_from_environment_variable()
plugin_manager.add_hookspecs(qx_plugin.QuiltixHookspecs)
```
which will cause the Qt module imports in the plugin.

Usd appears to be imported afterwards:
```
from pxr import Usd, UsdShade
```
By loading Qt when after_ui_init occurs:
```
plugin_manager.hook.after_ui_init(editor=self)
```
this seems to make this "run" at least.

## Test

Sample JSON plugin will load.

<img width="3204" height="1860" alt="image" src="https://github.com/user-attachments/assets/986396a6-59d7-449d-9daf-afe995039b82" />
